### PR TITLE
Add notification service and upgrade Spring Boot

### DIFF
--- a/account-service/build.gradle
+++ b/account-service/build.gradle
@@ -1,12 +1,15 @@
 plugins {
-  id 'org.springframework.boot' version '2.5.6'
-  id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'java'
+    id 'org.springframework.boot' version '3.2.5'
+    id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
 }
 
 group = 'com.eteration.simplebanking' // Changed group
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
 
 repositories {
   mavenCentral()

--- a/account-service/src/main/java/com/simplebanking/model/Account.java
+++ b/account-service/src/main/java/com/simplebanking/model/Account.java
@@ -1,6 +1,6 @@
 package com.simplebanking.model;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;

--- a/account-service/src/main/java/com/simplebanking/model/DepositTransaction.java
+++ b/account-service/src/main/java/com/simplebanking/model/DepositTransaction.java
@@ -1,7 +1,7 @@
 package com.simplebanking.model; // Corrected package
 
-import javax.persistence.Entity;
-import javax.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.DiscriminatorValue;
 
 @Entity
 @DiscriminatorValue("DepositTransaction")

--- a/account-service/src/main/java/com/simplebanking/model/Transaction.java
+++ b/account-service/src/main/java/com/simplebanking/model/Transaction.java
@@ -1,7 +1,7 @@
 package com.simplebanking.model; // Corrected package
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.Date;
 import java.util.UUID;
 

--- a/account-service/src/main/java/com/simplebanking/model/TransactionStatus.java
+++ b/account-service/src/main/java/com/simplebanking/model/TransactionStatus.java
@@ -1,0 +1,31 @@
+package com.simplebanking.model;
+
+public class TransactionStatus {
+    private String status;
+    private String approvalCode;
+
+    public TransactionStatus(String status, String approvalCode) {
+        this.status = status;
+        this.approvalCode = approvalCode;
+    }
+
+    public TransactionStatus(String status) {
+        this.status = status;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getApprovalCode() {
+        return approvalCode;
+    }
+
+    public void setApprovalCode(String approvalCode) {
+        this.approvalCode = approvalCode;
+    }
+}

--- a/account-service/src/main/java/com/simplebanking/model/WithdrawalTransaction.java
+++ b/account-service/src/main/java/com/simplebanking/model/WithdrawalTransaction.java
@@ -1,7 +1,7 @@
 package com.simplebanking.model; // Corrected package
 
-import javax.persistence.Entity;
-import javax.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.DiscriminatorValue;
 
 @Entity
 @DiscriminatorValue("WithdrawalTransaction")

--- a/account-service/src/main/java/com/simplebanking/services/AccountService.java
+++ b/account-service/src/main/java/com/simplebanking/services/AccountService.java
@@ -13,25 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
-
-// A simple DTO for transaction status response, define if not already present
-class TransactionStatus {
-    private String status;
-    private String approvalCode;
-
-    public TransactionStatus(String status, String approvalCode) {
-        this.status = status;
-        this.approvalCode = approvalCode;
-    }
-    public TransactionStatus(String status) {
-        this.status = status;
-    }
-
-    public String getStatus() { return status; }
-    public void setStatus(String status) { this.status = status; }
-    public String getApprovalCode() { return approvalCode; }
-    public void setApprovalCode(String approvalCode) { this.approvalCode = approvalCode; }
-}
+import com.simplebanking.model.TransactionStatus;
 
 
 @Service

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/notification-service/build.gradle
+++ b/notification-service/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'org.springframework.boot' version '3.2.5'
+    id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+}
+
+group = 'com.eteration.simplebanking'
+version = '0.0.1-SNAPSHOT'
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.kafka:spring-kafka'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/notification-service/src/main/java/com/simplebanking/NotificationApplication.java
+++ b/notification-service/src/main/java/com/simplebanking/NotificationApplication.java
@@ -1,0 +1,13 @@
+package com.simplebanking;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.kafka.annotation.EnableKafka;
+
+@SpringBootApplication
+@EnableKafka
+public class NotificationApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(NotificationApplication.class, args);
+    }
+}

--- a/notification-service/src/main/java/com/simplebanking/config/KafkaConsumerConfig.java
+++ b/notification-service/src/main/java/com/simplebanking/config/KafkaConsumerConfig.java
@@ -1,0 +1,42 @@
+package com.simplebanking.config;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.consumer.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Value("${spring.kafka.consumer.group-id}")
+    private String groupId;
+
+    @Bean
+    public ConsumerFactory<String, Object> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+}

--- a/notification-service/src/main/java/com/simplebanking/events/AccountCreatedEvent.java
+++ b/notification-service/src/main/java/com/simplebanking/events/AccountCreatedEvent.java
@@ -1,0 +1,16 @@
+package com.simplebanking.events;
+
+public class AccountCreatedEvent {
+    private String accountId;
+    private String owner;
+    // Add getters and setters
+    public AccountCreatedEvent() {}
+    public AccountCreatedEvent(String accountId, String owner) {
+        this.accountId = accountId;
+        this.owner = owner;
+    }
+    public String getAccountId() { return accountId; }
+    public void setAccountId(String accountId) { this.accountId = accountId; }
+    public String getOwner() { return owner; }
+    public void setOwner(String owner) { this.owner = owner; }
+}

--- a/notification-service/src/main/java/com/simplebanking/events/AccountCreditedEvent.java
+++ b/notification-service/src/main/java/com/simplebanking/events/AccountCreditedEvent.java
@@ -1,0 +1,22 @@
+package com.simplebanking.events;
+
+import java.util.Date;
+
+public class AccountCreditedEvent {
+    private String accountId;
+    private double amount;
+    private Date timestamp;
+    // Add getters and setters
+    public AccountCreditedEvent() {}
+    public AccountCreditedEvent(String accountId, double amount) {
+        this.accountId = accountId;
+        this.amount = amount;
+        this.timestamp = new Date();
+    }
+    public String getAccountId() { return accountId; }
+    public void setAccountId(String accountId) { this.accountId = accountId; }
+    public double getAmount() { return amount; }
+    public void setAmount(double amount) { this.amount = amount; }
+    public Date getTimestamp() { return timestamp; }
+    public void setTimestamp(Date timestamp) { this.timestamp = timestamp; }
+}

--- a/notification-service/src/main/java/com/simplebanking/events/AccountDebitedEvent.java
+++ b/notification-service/src/main/java/com/simplebanking/events/AccountDebitedEvent.java
@@ -1,0 +1,22 @@
+package com.simplebanking.events;
+
+import java.util.Date;
+
+public class AccountDebitedEvent {
+    private String accountId;
+    private double amount;
+    private Date timestamp;
+    // Add getters and setters
+    public AccountDebitedEvent() {}
+    public AccountDebitedEvent(String accountId, double amount) {
+        this.accountId = accountId;
+        this.amount = amount;
+        this.timestamp = new Date();
+    }
+    public String getAccountId() { return accountId; }
+    public void setAccountId(String accountId) { this.accountId = accountId; }
+    public double getAmount() { return amount; }
+    public void setAmount(double amount) { this.amount = amount; }
+    public Date getTimestamp() { return timestamp; }
+    public void setTimestamp(Date timestamp) { this.timestamp = timestamp; }
+}

--- a/notification-service/src/main/java/com/simplebanking/services/NotificationService.java
+++ b/notification-service/src/main/java/com/simplebanking/services/NotificationService.java
@@ -1,0 +1,29 @@
+package com.simplebanking.services;
+
+import com.simplebanking.events.AccountCreatedEvent;
+import com.simplebanking.events.AccountCreditedEvent;
+import com.simplebanking.events.AccountDebitedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NotificationService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NotificationService.class);
+    private static final String ACCOUNT_EVENTS_TOPIC = "account-events";
+
+    @KafkaListener(topics = ACCOUNT_EVENTS_TOPIC, groupId = "${spring.kafka.consumer.group-id}", containerFactory = "kafkaListenerContainerFactory")
+    public void handleEvent(Object event) {
+        if (event instanceof AccountCreatedEvent created) {
+            LOGGER.info("Notification: Account {} created for {}", created.getAccountId(), created.getOwner());
+        } else if (event instanceof AccountCreditedEvent credited) {
+            LOGGER.info("Notification: Account {} credited with {}", credited.getAccountId(), credited.getAmount());
+        } else if (event instanceof AccountDebitedEvent debited) {
+            LOGGER.info("Notification: Account {} debited by {}", debited.getAccountId(), debited.getAmount());
+        } else {
+            LOGGER.warn("Unknown event type: {}", event.getClass().getName());
+        }
+    }
+}

--- a/notification-service/src/main/resources/application.properties
+++ b/notification-service/src/main/resources/application.properties
@@ -1,0 +1,10 @@
+server.port=8082
+spring.application.name=notification-service
+
+# Kafka Consumer Properties
+spring.kafka.consumer.bootstrap-servers=localhost:9092
+spring.kafka.consumer.group-id=notification-group
+spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.JsonDeserializer
+spring.kafka.consumer.properties.spring.json.trusted.packages=*
+spring.kafka.listener.missing-topics-fatal=false

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
 rootProject.name = 'simple-banking-parent' // Optional: rename root project
 include 'account-service'
 include 'transaction-service'
+include 'notification-service'

--- a/transaction-service/build.gradle
+++ b/transaction-service/build.gradle
@@ -1,12 +1,15 @@
 plugins {
-  id 'org.springframework.boot' version '2.5.6'
-  id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'java'
+    id 'org.springframework.boot' version '3.2.5'
+    id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
 }
 
 group = 'com.eteration.simplebanking' // Changed group
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
 
 repositories {
   mavenCentral()

--- a/transaction-service/src/main/java/com/simplebanking/model/Transaction.java
+++ b/transaction-service/src/main/java/com/simplebanking/model/Transaction.java
@@ -1,9 +1,9 @@
 package com.simplebanking.model;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import java.util.Date;
 
 @Entity


### PR DESCRIPTION
## Summary
- update Gradle wrapper to 8.5
- upgrade account and transaction services to Spring Boot 3
- adjust entity imports to use `jakarta.persistence`
- add reusable `TransactionStatus` DTO
- introduce new **notification-service** that listens on Kafka and logs events
- include new module in the build

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_683f42e45d3c8332bfda9b3e09fce9fa